### PR TITLE
Changed brain persistence to mongodb

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -1,1 +1,1 @@
-["redis-brain.coffee", "tweet.coffee", "shipit.coffee"]
+["tweet.coffee", "shipit.coffee"]

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "hubot": "2.2.0",
     "hubot-irc": ">= 0.0.1",
     "hubot-scripts": ">=2.0.8",
-    "optparse": "1.0.3"
+    "optparse": "1.0.3",
+    "mongodb" : "*"
   },
   "engines": {
     "node": "0.6.x",

--- a/scripts/mongo-brain.coffee
+++ b/scripts/mongo-brain.coffee
@@ -3,22 +3,34 @@ mongodb = require "mongodb"
 
 # sets up hooks to persist the brain into redis.
 module.exports = (robot) ->
-  info   = Url.parse process.env.MONGO_URL || 'http://pepe:27017'
+  info   = Url.parse process.env.MONGO_URL || 'http://127.0.0.1:27017'
+  # define mongo server and client for hubot database.
   server = new mongodb.Server(info.hostname, (Number) info.port, {})
   client = new mongodb.Db("hubot", server);
 
+  #open a connection
   client.open (err, connection) ->
+    # create or retrieve the collection "storage"
     client.createCollection "storage", (err, collection) ->
-      cursor = collection.findOne {}, (err, doc) ->
+      #retrieve the one object from the database collection
+      collection.findOne {}, (err, doc) ->
+        # if an error ocurs, throw an exception
         if err 
           throw err
         else if doc
+          # else, merge the document into the robot brain.
           robot.brain.mergeData doc
 
+    # listen to the "save" event of the robot's brain.
     robot.brain.on 'save', (data) ->
+      # retrieve the collection storage.
       connection.collection 'storage', (err, collection) ->
+        # remove the object from the database.
         collection.remove {}
+        # save the new data provided by the robot brain.
         collection.save data
 
+    # listen to the "close" event of the robot's brain.
     robot.brain.on 'close', ->
+      # close the connection
       connection.close

--- a/scripts/mongo-brain.coffee
+++ b/scripts/mongo-brain.coffee
@@ -10,27 +10,30 @@ module.exports = (robot) ->
 
   #open a connection
   client.open (err, connection) ->
-    # create or retrieve the collection "storage"
-    client.createCollection "storage", (err, collection) ->
-      #retrieve the one object from the database collection
-      collection.findOne {}, (err, doc) ->
-        # if an error ocurs, throw an exception
-        if err 
-          throw err
-        else if doc
-          # else, merge the document into the robot brain.
-          robot.brain.mergeData doc
+    if err
+      throw err
+    else if connection
+      # create or retrieve the collection "storage"
+      client.createCollection "storage", (err, collection) ->
+        #retrieve the one object from the database collection
+        collection.findOne {}, (err, doc) ->
+          # if an error ocurs, throw an exception
+          if err 
+            throw err
+          else if doc
+            # else, merge the document into the robot brain.
+            robot.brain.mergeData doc
 
-    # listen to the "save" event of the robot's brain.
-    robot.brain.on 'save', (data) ->
-      # retrieve the collection storage.
-      connection.collection 'storage', (err, collection) ->
-        # remove the object from the database.
-        collection.remove {}
-        # save the new data provided by the robot brain.
-        collection.save data
+      # listen to the "save" event of the robot's brain.
+      robot.brain.on 'save', (data) ->
+        # retrieve the collection storage.
+        connection.collection 'storage', (err, collection) ->
+          # remove the object from the database.
+          collection.remove {}
+          # save the new data provided by the robot brain.
+          collection.save data
 
-    # listen to the "close" event of the robot's brain.
-    robot.brain.on 'close', ->
-      # close the connection
-      connection.close
+      # listen to the "close" event of the robot's brain.
+      robot.brain.on 'close', ->
+        # close the connection
+        connection.close

--- a/scripts/mongo-brain.coffee
+++ b/scripts/mongo-brain.coffee
@@ -1,0 +1,24 @@
+Url   = require "url"
+mongodb = require "mongodb"
+
+# sets up hooks to persist the brain into redis.
+module.exports = (robot) ->
+  info   = Url.parse process.env.MONGO_URL || 'http://pepe:27017'
+  server = new mongodb.Server(info.hostname, (Number) info.port, {})
+  client = new mongodb.Db("hubot", server);
+
+  client.open (err, connection) ->
+    client.createCollection "storage", (err, collection) ->
+      cursor = collection.findOne {}, (err, doc) ->
+        if err 
+          throw err
+        else if doc
+          robot.brain.mergeData doc
+
+    robot.brain.on 'save', (data) ->
+      connection.collection 'storage', (err, collection) ->
+        collection.remove {}
+        collection.save data
+
+    robot.brain.on 'close', ->
+      connection.close


### PR DESCRIPTION
I created a mongo-brain adapter that will work this way:
- When Boric starts, it fetchs an object from the "storage" collection.
- It merges that object into the robot.
- The it listens the robot's "save" event and replaces the object in the database with the provided one.

Closes #1
