### PR TITLE
Script that gives the URL to a bug in bugzilla

### DIFF
--- a/scripts/bugzilla.js
+++ b/scripts/bugzilla.js
@@ -1,0 +1,5 @@
+module.exports = function (robot) {
+   robot.hear(/bug#([0-9]+)/i, function(msg) {
+      msg.send('Bugzilla bug#'+msg.match[1]+': https://my.jwt.com/wwitbugs/show_bug.cgi?id='+msg.match[1])
+   });
+}


### PR DESCRIPTION
Example:
User> I was seeing the bug#1234 but cant reproduce it
Boric> Bugzilla bug#1234: https://my.jwt.com/wwitbugs/show_bug.cgi?id=1234
