### PR TITLE
Improved "ship it" response

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -1,3 +1,3 @@
-["tweet.coffee", "shipit.coffee", "decide.coffee", "ascii.coffee",
+["tweet.coffee", "decide.coffee", "ascii.coffee",
  "eight-ball.coffee", "fibonacci.coffee", "faceup.coffee", "invalid.coffee", "location-decision-maker.coffee",
  "polite.coffee"]

--- a/scripts/google-images.coffee
+++ b/scripts/google-images.coffee
@@ -24,6 +24,10 @@ module.exports = (robot) ->
       imageMe msg, imagery, (url) ->
         msg.send "#{mustachify}#{url}"
 
+  robot.hear /ship it/i, (msg) ->
+    imageMe msg, 'ship it squirrel', (url) ->
+      msg.send url
+
 imageMe = (msg, query, cb) ->
   msg.http('http://ajax.googleapis.com/ajax/services/search/images')
     .query(v: "1.0", rsz: '8', q: query, safe: 'active')


### PR DESCRIPTION
Change it so, instead of returning a "random" url from a static list,
it returns an image from a query ("ship it" meme) in Google Image.

Reused the google-images script.

Deleted the ship-it script from the hubot-scripts.json,
so it doesn't import the original script.

Closes issue  #2
